### PR TITLE
Simplify AstPass lifetimes

### DIFF
--- a/diesel/src/expression/array_comparison.rs
+++ b/diesel/src/expression/array_comparison.rs
@@ -55,10 +55,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::ArrayComparision>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
     }
 }
@@ -71,10 +68,7 @@ where
     T: QueryFragment<DB>,
     U: QueryFragment<DB> + MaybeEmpty,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.values.is_empty() {
             out.push_sql("1=0");
         } else {
@@ -92,10 +86,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::ArrayComparision>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
     }
 }
@@ -108,10 +99,7 @@ where
     T: QueryFragment<DB>,
     U: QueryFragment<DB> + MaybeEmpty,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.values.is_empty() {
             out.push_sql("1=1");
         } else {
@@ -227,10 +215,7 @@ where
     Self: QueryFragment<DB, DB::ArrayComparision>,
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::ArrayComparision>>::walk_ast(self, pass)
     }
 }
@@ -244,10 +229,7 @@ where
     ST: SingleValue,
     I: ToSql<ST, DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         let mut first = true;
         for value in &self.0 {

--- a/diesel/src/expression/assume_not_null.rs
+++ b/diesel/src/expression/assume_not_null.rs
@@ -29,10 +29,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/bound.rs
+++ b/diesel/src/expression/bound.rs
@@ -34,10 +34,7 @@ where
     DB: Backend + HasSqlType<T>,
     U: ToSql<T, DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         pass.push_bind_param(&self.item)?;
         Ok(())
     }

--- a/diesel/src/expression/coerce.rs
+++ b/diesel/src/expression/coerce.rs
@@ -60,10 +60,7 @@ where
     T: QueryFragment<DB>,
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.expr.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/count.rs
+++ b/diesel/src/expression/count.rs
@@ -68,10 +68,7 @@ impl Expression for CountStar {
 }
 
 impl<DB: Backend> QueryFragment<DB> for CountStar {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("COUNT(*)");
         Ok(())
     }
@@ -152,10 +149,7 @@ where
     DB: Backend,
     E: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("COUNT(DISTINCT ");
         self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/expression/exists.rs
+++ b/diesel/src/expression/exists.rs
@@ -55,10 +55,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::ExistsSyntax>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::ExistsSyntax>>::walk_ast(self, pass)
     }
 }
@@ -68,10 +65,7 @@ where
     DB: Backend + SqlDialect<ExistsSyntax = sql_dialect::exists_syntax::AnsiSqlExistsSyntax>,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("EXISTS (");
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/expression/functions/date_and_time.rs
+++ b/diesel/src/expression/functions/date_and_time.rs
@@ -17,10 +17,7 @@ impl Expression for now {
 }
 
 impl<DB: Backend> QueryFragment<DB> for now {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("CURRENT_TIMESTAMP");
         Ok(())
     }
@@ -85,10 +82,7 @@ impl Expression for today {
 }
 
 impl<DB: Backend> QueryFragment<DB> for today {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("CURRENT_DATE");
         Ok(())
     }

--- a/diesel/src/expression/functions/mod.rs
+++ b/diesel/src/expression/functions/mod.rs
@@ -35,8 +35,7 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend + $($constraint)::+,
         {
-            fn walk_ast<'a: 'b, 'b>(&'a self, mut out: $crate::query_builder::AstPass<'_, 'b, DB>)
-                -> $crate::result::QueryResult<()>
+            fn walk_ast<'b>(&'b self, mut out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
             {
                 out.push_sql(concat!(stringify!($type_name), "()"));
                 Ok(())
@@ -50,7 +49,7 @@ macro_rules! no_arg_sql_function_body {
         impl<DB> $crate::query_builder::QueryFragment<DB> for $type_name where
             DB: $crate::backend::Backend,
         {
-            fn walk_ast<'a: 'b, 'b>(&'a self, mut out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()> {
+            fn walk_ast<'b>(&'b self, mut out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()> {
                 out.push_sql(concat!(stringify!($type_name), "()"));
                 Ok(())
             }

--- a/diesel/src/expression/grouped.rs
+++ b/diesel/src/expression/grouped.rs
@@ -12,10 +12,7 @@ impl<T: Expression> Expression for Grouped<T> {
 }
 
 impl<T: QueryFragment<DB>, DB: Backend> QueryFragment<DB> for Grouped<T> {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("(");
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/expression/nullable.rs
+++ b/diesel/src/expression/nullable.rs
@@ -29,10 +29,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -93,11 +93,10 @@ macro_rules! __diesel_operator_body {
                 $($ty_param: $crate::query_builder::QueryFragment<$backend_ty>,)+
                 $($backend_ty_param: $crate::backend::Backend,)*
         {
-            fn walk_ast<'a, 'b>(
-                &'a self,
+            fn walk_ast<'b>(
+                &'b self,
                 mut out: $crate::query_builder::AstPass<'_, 'b, $backend_ty>
             ) -> $crate::result::QueryResult<()>
-            where 'a: 'b
             {
                 $crate::__diesel_operator_to_sql!(
                     notation = $notation,
@@ -590,13 +589,10 @@ where
     R: QueryFragment<DB>,
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(
-        &'a self,
+    fn walk_ast<'b>(
+        &'b self,
         mut out: crate::query_builder::AstPass<'_, 'b, DB>,
-    ) -> crate::result::QueryResult<()>
-    where
-        'a: 'b,
-    {
+    ) -> crate::result::QueryResult<()> {
         // Those brackets are required because mysql is broken
         // https://github.com/diesel-rs/diesel/issues/2133#issuecomment-517432317
         out.push_sql("(");

--- a/diesel/src/expression/ops/numeric.rs
+++ b/diesel/src/expression/ops/numeric.rs
@@ -37,8 +37,7 @@ macro_rules! numeric_operation {
             Lhs: QueryFragment<DB>,
             Rhs: QueryFragment<DB>,
         {
-            fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-                where 'a: 'b
+            fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
             {
                 out.push_sql("(");
                 self.lhs.walk_ast(out.reborrow())?;

--- a/diesel/src/expression/select_by.rs
+++ b/diesel/src/expression/select_by.rs
@@ -102,10 +102,7 @@ where
     T::SelectExpression: QueryFragment<DB>,
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(&'a self, out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.selection.walk_ast(out)
     }
 }

--- a/diesel/src/expression/sql_literal.rs
+++ b/diesel/src/expression/sql_literal.rs
@@ -168,10 +168,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.inner.walk_ast(out.reborrow())?;
         out.push_sql(&self.sql);
@@ -348,10 +345,7 @@ where
     Query: QueryFragment<DB>,
     Value: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.query.walk_ast(out.reborrow())?;
         self.value.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/expression/subselect.rs
+++ b/diesel/src/expression/subselect.rs
@@ -60,10 +60,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.values.walk_ast(out.reborrow())?;
         Ok(())
     }

--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -185,7 +185,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::InsertWithDefaultKeyword>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::InsertWithDefaultKeyword>>::walk_ast(self, pass)
     }
 }
@@ -195,7 +195,7 @@ where
     DB: Backend + SqlDialect<InsertWithDefaultKeyword = sql_dialect::default_keyword_for_insert::IsoSqlDefaultKeyword>,
     Expr: QueryFragment<DB>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         if let Self::Expression(ref inner) = *self {
             inner.walk_ast(out.reborrow())?;
@@ -211,7 +211,7 @@ where
     DB: Backend,
     Expr: QueryFragment<DB>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.expr.walk_ast(pass)
     }
 }
@@ -241,10 +241,7 @@ impl<Col, Expr>
 where
     Expr: QueryFragment<crate::sqlite::Sqlite>,
 {
-    fn walk_ast<'a: 'b, 'b>(
-        &'a self,
-        mut out: AstPass<'_, 'b, crate::sqlite::Sqlite>,
-    ) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, crate::sqlite::Sqlite>) -> QueryResult<()> {
         if let Self::Expression(ref inner) = *self {
             inner.walk_ast(out.reborrow())?;
         }

--- a/diesel/src/macros/mod.rs
+++ b/diesel/src/macros/mod.rs
@@ -71,8 +71,7 @@ macro_rules! __diesel_column {
             <$table as $crate::QuerySource>::FromClause: $crate::query_builder::QueryFragment<DB>,
         {
             #[allow(non_snake_case)]
-            fn walk_ast<'a, 'b>(&'a self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
-            where 'a: 'b
+            fn walk_ast<'b>(&'b self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
             {
                 use $crate::QuerySource;
                 const FROM_CLAUSE: $crate::query_builder::nodes::StaticQueryFragmentInstance<table> = $crate::query_builder::nodes::StaticQueryFragmentInstance::new();
@@ -886,8 +885,7 @@ macro_rules! __diesel_table_impl {
                     <table as $crate::QuerySource>::FromClause: $crate::query_builder::QueryFragment<DB>,
                 {
                     #[allow(non_snake_case)]
-                    fn walk_ast<'a, 'b>(&'a self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
-                        where 'a: 'b
+                    fn walk_ast<'b>(&'b self, mut __out: $crate::query_builder::AstPass<'_, 'b, DB>) -> $crate::result::QueryResult<()>
                     {
                         use $crate::QuerySource;
                         const FROM_CLAUSE: $crate::query_builder::nodes::StaticQueryFragmentInstance<table> = $crate::query_builder::nodes::StaticQueryFragmentInstance::new();

--- a/diesel/src/mysql/query_builder/limit_offset.rs
+++ b/diesel/src/mysql/query_builder/limit_offset.rs
@@ -6,7 +6,7 @@ use crate::query_builder::{AstPass, IntoBoxedClause, QueryFragment};
 use crate::result::QueryResult;
 
 impl QueryFragment<Mysql> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
-    fn walk_ast<'a: 'b, 'b>(&'a self, _out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -15,7 +15,7 @@ impl<L> QueryFragment<Mysql> for LimitOffsetClause<LimitClause<L>, NoOffsetClaus
 where
     LimitClause<L>: QueryFragment<Mysql>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         self.limit_clause.walk_ast(out)?;
         Ok(())
     }
@@ -26,7 +26,7 @@ where
     LimitClause<L>: QueryFragment<Mysql>,
     OffsetClause<O>: QueryFragment<Mysql>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         self.limit_clause.walk_ast(out.reborrow())?;
         self.offset_clause.walk_ast(out.reborrow())?;
         Ok(())
@@ -34,7 +34,7 @@ where
 }
 
 impl<'a> QueryFragment<Mysql> for BoxedLimitOffsetClause<'a, Mysql> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         match (self.limit.as_ref(), self.offset.as_ref()) {
             (Some(limit), Some(offset)) => {
                 limit.walk_ast(out.reborrow())?;

--- a/diesel/src/mysql/query_builder/query_fragment_impls.rs
+++ b/diesel/src/mysql/query_builder/query_fragment_impls.rs
@@ -4,41 +4,41 @@ use crate::query_builder::{AstPass, DefaultValues, QueryFragment};
 use crate::result::QueryResult;
 
 impl QueryFragment<Mysql> for ForUpdate {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql(" FOR UPDATE");
         Ok(())
     }
 }
 
 impl QueryFragment<Mysql> for ForShare {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql(" FOR SHARE");
         Ok(())
     }
 }
 
 impl QueryFragment<Mysql> for NoModifier {
-    fn walk_ast<'a: 'b, 'b>(&'a self, _out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         Ok(())
     }
 }
 
 impl QueryFragment<Mysql> for SkipLocked {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql(" SKIP LOCKED");
         Ok(())
     }
 }
 
 impl QueryFragment<Mysql> for NoWait {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql(" NOWAIT");
         Ok(())
     }
 }
 
 impl QueryFragment<Mysql, crate::mysql::backend::MysqlStyleDefaultValueClause> for DefaultValues {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql("() VALUES ()");
         Ok(())
     }

--- a/diesel/src/pg/expression/array.rs
+++ b/diesel/src/pg/expression/array.rs
@@ -69,10 +69,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a: 'b, 'b>(
-        &'a self,
-        mut out: AstPass<'_, 'b, DB>,
-    ) -> crate::result::QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> crate::result::QueryResult<()> {
         out.push_sql("ARRAY[");
         QueryFragment::walk_ast(&self.elements, out.reborrow())?;
         out.push_sql("]");

--- a/diesel/src/pg/expression/array_comparison.rs
+++ b/diesel/src/pg/expression/array_comparison.rs
@@ -86,7 +86,7 @@ impl<Expr> QueryFragment<Pg> for Any<Expr>
 where
     Expr: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("ANY(");
         self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");
@@ -120,7 +120,7 @@ impl<Expr> QueryFragment<Pg> for All<Expr>
 where
     Expr: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("ALL(");
         self.expr.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/pg/expression/date_and_time.rs
+++ b/diesel/src/pg/expression/date_and_time.rs
@@ -39,7 +39,7 @@ where
     Ts: QueryFragment<Pg>,
     Tz: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         self.timestamp.walk_ast(out.reborrow())?;
         out.push_sql(" AT TIME ZONE ");
         self.timezone.walk_ast(out.reborrow())?;

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -27,7 +27,7 @@ impl<T> QueryFragment<Pg> for DistinctOnClause<T>
 where
     T: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("DISTINCT ON (");
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/pg/query_builder/limit_offset.rs
+++ b/diesel/src/pg/query_builder/limit_offset.rs
@@ -19,7 +19,7 @@ where
 }
 
 impl<'a> QueryFragment<Pg> for BoxedLimitOffsetClause<'a, Pg> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         if let Some(ref limit) = self.limit {
             limit.walk_ast(out.reborrow())?;
         }
@@ -35,7 +35,7 @@ where
     L: QueryFragment<Pg>,
     O: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         self.limit_clause.walk_ast(out.reborrow())?;
         self.offset_clause.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/pg/query_builder/on_constraint.rs
+++ b/diesel/src/pg/query_builder/on_constraint.rs
@@ -59,7 +59,7 @@ impl<'a> QueryId for OnConstraint<'a> {
 }
 
 impl<'a> QueryFragment<Pg, PgOnConflictClaues> for ConflictTarget<OnConstraint<'a>> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_sql(" ON CONSTRAINT ");
         out.push_identifier(self.0.constraint_name)?;

--- a/diesel/src/pg/query_builder/only_clause.rs
+++ b/diesel/src/pg/query_builder/only_clause.rs
@@ -17,7 +17,7 @@ impl<T> QueryFragment<Pg> for Only<T>
 where
     T: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("ONLY ");
         self.query.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/pg/query_builder/query_fragment_impls.rs
+++ b/diesel/src/pg/query_builder/query_fragment_impls.rs
@@ -12,48 +12,48 @@ use crate::serialize::ToSql;
 use crate::sql_types::{HasSqlType, SingleValue};
 
 impl QueryFragment<Pg> for ForUpdate {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" FOR UPDATE");
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for ForNoKeyUpdate {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" FOR NO KEY UPDATE");
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for ForShare {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" FOR SHARE");
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for ForKeyShare {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" FOR KEY SHARE");
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for NoModifier {
-    fn walk_ast<'a: 'b, 'b>(&'a self, _out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for SkipLocked {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" SKIP LOCKED");
         Ok(())
     }
 }
 
 impl QueryFragment<Pg> for NoWait {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" NOWAIT");
         Ok(())
     }
@@ -64,7 +64,7 @@ where
     T: QueryFragment<Pg>,
     U: QueryFragment<Pg> + MaybeEmpty,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         self.left.walk_ast(out.reborrow())?;
         out.push_sql(" = ANY(");
         self.values.walk_ast(out.reborrow())?;
@@ -78,7 +78,7 @@ where
     T: QueryFragment<Pg>,
     U: QueryFragment<Pg> + MaybeEmpty,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         self.left.walk_ast(out.reborrow())?;
         out.push_sql(" != ALL(");
         self.values.walk_ast(out.reborrow())?;
@@ -93,7 +93,7 @@ where
     Vec<I>: ToSql<Array<ST>, Pg>,
     Pg: HasSqlType<ST>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_bind_param::<Array<ST>, Vec<I>>(&self.0)
     }
 }
@@ -104,7 +104,7 @@ where
     T: QueryFragment<Pg>,
     U: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         self.target.walk_ast(out.reborrow())?;
         self.where_clause.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/pg/transaction.rs
+++ b/diesel/src/pg/transaction.rs
@@ -293,7 +293,7 @@ where
 }
 
 impl<'a, C> QueryFragment<Pg> for TransactionBuilder<'a, C> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("BEGIN TRANSACTION");
         if let Some(ref isolation_level) = self.isolation_level {
             isolation_level.walk_ast(out.reborrow())?;
@@ -316,7 +316,7 @@ enum IsolationLevel {
 }
 
 impl QueryFragment<Pg> for IsolationLevel {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql(" ISOLATION LEVEL ");
         match *self {
             IsolationLevel::ReadCommitted => out.push_sql("READ COMMITTED"),
@@ -334,7 +334,7 @@ enum ReadMode {
 }
 
 impl QueryFragment<Pg> for ReadMode {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         match *self {
             ReadMode::ReadOnly => out.push_sql(" READ ONLY"),
             ReadMode::ReadWrite => out.push_sql(" READ WRITE"),
@@ -350,7 +350,7 @@ enum Deferrable {
 }
 
 impl QueryFragment<Pg> for Deferrable {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         match *self {
             Deferrable::Deferrable => out.push_sql(" DEFERRABLE"),
             Deferrable::NotDeferrable => out.push_sql(" NOT DEFERRABLE"),

--- a/diesel/src/pg/types/record.rs
+++ b/diesel/src/pg/types/record.rs
@@ -135,7 +135,7 @@ impl<T> QueryFragment<Pg> for PgTuple<T>
 where
     T: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("(");
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(")");

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -151,7 +151,7 @@ where
     ///     Left: QueryFragment<DB>,
     ///     Right: QueryFragment<DB>,
     /// {
-    ///     fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    ///     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
     ///         self.left.walk_ast(out.reborrow())?;
     ///         out.push_sql(" AND ");
     ///         self.right.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/clause_macro.rs
+++ b/diesel/src/query_builder/clause_macro.rs
@@ -34,8 +34,7 @@ macro_rules! simple_clause {
         pub struct $no_clause;
 
         impl<DB: Backend> QueryFragment<DB> for $no_clause {
-            fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-            where 'a: 'b
+            fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
             {
                 Ok(())
             }
@@ -49,8 +48,7 @@ macro_rules! simple_clause {
             DB: Backend $(+ $backend_bounds)*,
             Expr: QueryFragment<DB>,
         {
-            fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-            where 'a: 'b
+            fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
             {
                 out.push_sql($sql);
                 self.0.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/combination_clause.rs
+++ b/diesel/src/query_builder/combination_clause.rs
@@ -11,10 +11,7 @@ use crate::{CombineDsl, Insertable, QueryResult, RunQueryDsl, Table};
 pub struct NoCombinationClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoCombinationClause {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -133,10 +130,7 @@ where
     RhsParenthesisWrapper<Rhs>: QueryFragment<DB>,
     DB: Backend + SupportsCombinationClause<Combinator, Rule>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.source.walk_ast(out.reborrow())?;
         self.combinator.walk_ast(out.reborrow())?;
         self.duplicate_rule.walk_ast(out.reborrow())?;
@@ -149,10 +143,7 @@ where
 pub struct Union;
 
 impl<DB: Backend> QueryFragment<DB> for Union {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" UNION ");
         Ok(())
     }
@@ -163,10 +154,7 @@ impl<DB: Backend> QueryFragment<DB> for Union {
 pub struct Intersect;
 
 impl<DB: Backend> QueryFragment<DB> for Intersect {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" INTERSECT ");
         Ok(())
     }
@@ -177,10 +165,7 @@ impl<DB: Backend> QueryFragment<DB> for Intersect {
 pub struct Except;
 
 impl<DB: Backend> QueryFragment<DB> for Except {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" EXCEPT ");
         Ok(())
     }
@@ -191,10 +176,7 @@ impl<DB: Backend> QueryFragment<DB> for Except {
 pub struct Distinct;
 
 impl<DB: Backend> QueryFragment<DB> for Distinct {
-    fn walk_ast<'a, 'b>(&'a self, _out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -204,10 +186,7 @@ impl<DB: Backend> QueryFragment<DB> for Distinct {
 pub struct All;
 
 impl<DB: Backend> QueryFragment<DB> for All {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("ALL ");
         Ok(())
     }
@@ -228,10 +207,7 @@ mod postgres {
     use crate::QueryResult;
 
     impl<T: QueryFragment<Pg>> QueryFragment<Pg> for RhsParenthesisWrapper<T> {
-        fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()>
-        where
-            'a: 'b,
-        {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
             out.push_sql("(");
             self.0.walk_ast(out.reborrow())?;
             out.push_sql(")");
@@ -255,10 +231,7 @@ mod mysql {
     use crate::QueryResult;
 
     impl<T: QueryFragment<Mysql>> QueryFragment<Mysql> for RhsParenthesisWrapper<T> {
-        fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()>
-        where
-            'a: 'b,
-        {
+        fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
             out.push_sql("(");
             self.0.walk_ast(out.reborrow())?;
             out.push_sql(")");
@@ -278,10 +251,7 @@ mod sqlite {
     use crate::QueryResult;
 
     impl<T: QueryFragment<Sqlite>> QueryFragment<Sqlite> for RhsParenthesisWrapper<T> {
-        fn walk_ast<'a, 'b>(&'a self, out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-        where
-            'a: 'b,
-        {
+        fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
             self.0.walk_ast(out) // SQLite does not support parenthesis around Ths
         }
     }

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -211,10 +211,7 @@ where
     U: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("DELETE ");
         self.from_clause.walk_ast(out.reborrow())?;
         self.where_clause.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/distinct_clause.rs
+++ b/diesel/src/query_builder/distinct_clause.rs
@@ -9,19 +9,13 @@ pub struct NoDistinctClause;
 pub struct DistinctClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoDistinctClause {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
 
 impl<DB: Backend> QueryFragment<DB> for DistinctClause {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("DISTINCT ");
         Ok(())
     }

--- a/diesel/src/query_builder/from_clause.rs
+++ b/diesel/src/query_builder/from_clause.rs
@@ -12,10 +12,7 @@ where
     Self: QueryFragment<DB, DB::EmptyFromClauseSyntax>,
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::EmptyFromClauseSyntax>>::walk_ast(self, pass)
     }
 }
@@ -25,7 +22,7 @@ impl<DB> QueryFragment<DB, crate::backend::sql_dialect::from_clause_syntax::Ansi
 where
     DB: Backend<EmptyFromClauseSyntax = crate::backend::sql_dialect::from_clause_syntax::AnsiSqlFromClauseSyntax>,
 {
-    fn walk_ast<'a, 'b>(&'a self, _pass: AstPass<'_, 'b, DB>) -> QueryResult<()> where 'a: 'b {
+    fn walk_ast<'b>(&'b self, _pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -120,10 +117,7 @@ where
     DB: Backend,
     F::FromClause: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         pass.push_sql(" FROM ");
         self.from_clause.walk_ast(pass)
     }

--- a/diesel/src/query_builder/insert_statement/batch_insert.rs
+++ b/diesel/src/query_builder/insert_statement/batch_insert.rs
@@ -82,10 +82,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::BatchInsertSupport>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::BatchInsertSupport>>::walk_ast(self, pass)
     }
 }
@@ -102,10 +99,7 @@ where
     ValuesClause<V, Tab>: QueryFragment<DB>,
     V: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if !HAS_STATIC_QUERY_ID {
             out.unsafe_to_cache_prepared();
         }

--- a/diesel/src/query_builder/insert_statement/insert_from_select.rs
+++ b/diesel/src/query_builder/insert_statement/insert_from_select.rs
@@ -49,10 +49,7 @@ where
     Columns: ColumnList + Expression,
     Select: Query<SqlType = Columns::SqlType> + QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("(");
         self.columns.walk_ast(out.reborrow())?;
         out.push_sql(") ");

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -263,10 +263,7 @@ where
     ValuesClause<V, Tab>: QueryFragment<Sqlite>,
     V: QueryFragment<Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         if !STATIC_QUERY_ID {
             out.unsafe_to_cache_prepared();
         }

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -198,10 +198,7 @@ where
     Op: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.records.rows_to_insert() == Some(0) {
             out.push_sql("SELECT 1 FROM ");
             self.into_clause.walk_ast(out.reborrow())?;
@@ -282,10 +279,7 @@ impl<T: QuerySource, U, Op> InsertStatement<T, U, Op> {
 pub struct Insert;
 
 impl<DB: Backend> QueryFragment<DB> for Insert {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("INSERT");
         Ok(())
     }
@@ -297,10 +291,7 @@ pub struct InsertOrIgnore;
 
 #[cfg(feature = "sqlite")]
 impl QueryFragment<Sqlite> for InsertOrIgnore {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         out.push_sql("INSERT OR IGNORE");
         Ok(())
     }
@@ -308,10 +299,7 @@ impl QueryFragment<Sqlite> for InsertOrIgnore {
 
 #[cfg(feature = "mysql")]
 impl QueryFragment<Mysql> for InsertOrIgnore {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql("INSERT IGNORE");
         Ok(())
     }
@@ -323,10 +311,7 @@ pub struct Replace;
 
 #[cfg(feature = "sqlite")]
 impl QueryFragment<Sqlite> for Replace {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         out.push_sql("REPLACE");
         Ok(())
     }
@@ -334,10 +319,7 @@ impl QueryFragment<Sqlite> for Replace {
 
 #[cfg(feature = "mysql")]
 impl QueryFragment<Mysql> for Replace {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.push_sql("REPLACE");
         Ok(())
     }
@@ -426,10 +408,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::DefaultValueClauseForInsert>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::DefaultValueClauseForInsert>>::walk_ast(self, pass)
     }
 }
@@ -442,10 +421,7 @@ where
             DefaultValueClauseForInsert = sql_dialect::default_value_clause::AnsiDefaultValueClause,
         >,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("DEFAULT VALUES");
         Ok(())
     }
@@ -490,10 +466,7 @@ where
     T: InsertValues<Tab, DB>,
     DefaultValues: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.values.is_noop()? {
             DefaultValues.walk_ast(out)?;
         } else {

--- a/diesel/src/query_builder/locking_clause.rs
+++ b/diesel/src/query_builder/locking_clause.rs
@@ -6,10 +6,7 @@ use crate::result::QueryResult;
 pub struct NoLockingClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoLockingClause {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -32,10 +29,7 @@ impl<LockMode, Modifier> LockingClause<LockMode, Modifier> {
 impl<DB: Backend, L: QueryFragment<DB>, M: QueryFragment<DB>> QueryFragment<DB>
     for LockingClause<L, M>
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.lock_mode.walk_ast(out.reborrow())?;
         self.modifier.walk_ast(out.reborrow())
     }

--- a/diesel/src/query_builder/nodes/mod.rs
+++ b/diesel/src/query_builder/nodes/mod.rs
@@ -24,7 +24,7 @@ where
     T: StaticQueryFragment,
     T::Component: QueryFragment<DB>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         T::STATIC_COMPONENT.walk_ast(pass)
     }
 }
@@ -33,7 +33,7 @@ where
 pub struct Identifier<'a>(pub &'a str);
 
 impl<'a, DB: Backend> QueryFragment<DB> for Identifier<'a> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_identifier(self.0)
     }
 }
@@ -68,7 +68,7 @@ where
     U: QueryFragment<DB>,
     M: MiddleFragment<DB>,
 {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.lhs.walk_ast(out.reborrow())?;
         self.middle.push_sql(out.reborrow());
         self.rhs.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/returning_clause.rs
+++ b/diesel/src/query_builder/returning_clause.rs
@@ -7,10 +7,7 @@ use crate::result::QueryResult;
 pub struct NoReturningClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoReturningClause {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -24,10 +21,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::ReturningClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::ReturningClause>>::walk_ast(self, pass)
     }
 }
@@ -41,10 +35,7 @@ where
     >,
     Expr: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" RETURNING ");
         self.0.walk_ast(out.reborrow())?;
         Ok(())

--- a/diesel/src/query_builder/select_clause.rs
+++ b/diesel/src/query_builder/select_clause.rs
@@ -103,10 +103,7 @@ where
     DB: Backend,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.0.walk_ast(pass)
     }
 }
@@ -117,10 +114,7 @@ where
     QS: AsQuerySource,
     <QS::QuerySource as QuerySource>::DefaultSelection: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.default_seletion.walk_ast(pass)
     }
 }

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -164,10 +164,7 @@ where
     QS: QueryFragment<DB>,
     BoxedLimitOffsetClause<'a, DB>: QueryFragment<DB>,
 {
-    fn walk_ast<'b, 'c>(&'b self, out: AstPass<'_, 'c, DB>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.build_query(out, |where_clause, out| where_clause.walk_ast(out))
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -144,10 +144,7 @@ where
     H: QueryFragment<DB>,
     LC: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("SELECT ");
         self.distinct.walk_ast(out.reborrow())?;
         self.select.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -102,10 +102,7 @@ where
     DB: Backend,
     Inner: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.inner.walk_ast(out.reborrow())?;
         out.push_sql(&self.query);
@@ -232,10 +229,7 @@ where
     Query: QueryFragment<DB>,
     Value: ToSql<ST, DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.query.walk_ast(out.reborrow())?;
         out.push_bind_param_value_only(&self.value)?;
         Ok(())
@@ -269,10 +263,7 @@ where
     DB: Backend + HasSqlType<ST>,
     U: ToSql<ST, DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         pass.push_bind_param_value_only(&self.value)
     }
 }
@@ -316,10 +307,7 @@ where
     DB: Backend,
     Query: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.query.walk_ast(out.reborrow())?;
         out.push_sql(&self.sql);

--- a/diesel/src/query_builder/update_statement/changeset.rs
+++ b/diesel/src/query_builder/update_statement/changeset.rs
@@ -77,10 +77,7 @@ where
     T: Column,
     U: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_identifier(T::NAME)?;
         out.push_sql(" = ");
         QueryFragment::walk_ast(&self.expr, out)

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -198,10 +198,7 @@ where
     V: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         if self.values.is_noop()? {
             return Err(QueryBuilderError(
                 "There are no changes to save. This query cannot be built".into(),

--- a/diesel/src/query_builder/upsert/into_conflict_clause.rs
+++ b/diesel/src/query_builder/upsert/into_conflict_clause.rs
@@ -28,10 +28,7 @@ impl<S> QueryFragment<crate::pg::Pg> for OnConflictSelectWrapper<S>
 where
     S: QueryFragment<crate::pg::Pg>,
 {
-    fn walk_ast<'a, 'b>(&'a self, out: AstPass<'_, 'b, crate::pg::Pg>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, crate::pg::Pg>) -> QueryResult<()> {
         self.0.walk_ast(out)
     }
 }
@@ -45,10 +42,7 @@ where
     SelectStatement<F, S, D, WhereClause<W>, O, LOf, G, H, LC>:
         QueryFragment<crate::sqlite::Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, out: AstPass<'_, 'b, crate::sqlite::Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, crate::sqlite::Sqlite>) -> QueryResult<()> {
         self.0.walk_ast(out)
     }
 }
@@ -61,10 +55,7 @@ where
         QueryFragment<crate::sqlite::Sqlite>,
     QS: QueryFragment<crate::sqlite::Sqlite>,
 {
-    fn walk_ast<'b, 'c>(&'b self, pass: AstPass<'_, 'c, crate::sqlite::Sqlite>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, crate::sqlite::Sqlite>) -> QueryResult<()> {
         // https://www.sqlite.org/lang_UPSERT.html (Parsing Ambiguity)
         self.0.build_query(pass, |where_clause, mut pass| {
             match where_clause {

--- a/diesel/src/query_builder/upsert/on_conflict_actions.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_actions.rs
@@ -13,10 +13,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::OnConflictClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::OnConflictClause>>::walk_ast(self, pass)
     }
 }
@@ -26,10 +23,7 @@ where
     DB: Backend,
     T: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" DO NOTHING");
         Ok(())
     }
@@ -52,10 +46,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::OnConflictClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::OnConflictClause>>::walk_ast(self, pass)
     }
 }
@@ -66,10 +57,7 @@ where
     SP: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
     T: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         if self.changeset.is_noop()? {
             out.push_sql(" DO NOTHING");
@@ -96,10 +84,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::OnConflictClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::OnConflictClause>>::walk_ast(self, pass)
     }
 }
@@ -110,10 +95,7 @@ where
     SP: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
     T: Column,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("excluded.");
         out.push_identifier(T::NAME)?;
         Ok(())

--- a/diesel/src/query_builder/upsert/on_conflict_clause.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_clause.rs
@@ -56,10 +56,7 @@ where
     Target: QueryFragment<DB>,
     Action: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.values.walk_ast(out.reborrow())?;
         out.push_sql(" ON CONFLICT");
         self.target.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/upsert/on_conflict_target.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target.rs
@@ -16,10 +16,7 @@ where
     DB: Backend,
     DB::OnConflictClause: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
 {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -35,10 +32,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::OnConflictClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::OnConflictClause>>::walk_ast(self, pass)
     }
 }
@@ -49,10 +43,7 @@ where
     SP: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
     T: Column,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" (");
         out.push_identifier(T::NAME)?;
         out.push_sql(")");
@@ -68,10 +59,7 @@ where
     SP: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
     SqlLiteral<ST>: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" ");
         self.0.walk_ast(out.reborrow())?;
         Ok(())
@@ -86,10 +74,7 @@ where
     SP: sql_dialect::on_conflict_clause::SupportsOnConflictClause,
     T: Column,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" (");
         out.push_identifier(T::NAME)?;
         out.push_sql(")");
@@ -112,8 +97,7 @@ macro_rules! on_conflict_tuples {
                 _T: Column,
                 $($T: Column<Table=_T::Table>,)*
             {
-                fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, _DB>) -> QueryResult<()>
-                where 'a: 'b
+                fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, _DB>) -> QueryResult<()>
                 {
                     out.push_sql(" (");
                     out.push_identifier(_T::NAME)?;

--- a/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
+++ b/diesel/src/query_builder/upsert/on_conflict_target_decorations.rs
@@ -62,10 +62,7 @@ where
     DB: Backend,
     Self: QueryFragment<DB, DB::OnConflictClause>,
 {
-    fn walk_ast<'a, 'b>(&'a self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         <Self as QueryFragment<DB, DB::OnConflictClause>>::walk_ast(self, pass)
     }
 }

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -32,10 +32,7 @@ pub trait WhereOr<Predicate> {
 pub struct NoWhereClause;
 
 impl<DB: Backend> QueryFragment<DB> for NoWhereClause {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -79,10 +76,7 @@ where
     DB: Backend,
     Expr: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" WHERE ");
         self.0.walk_ast(out.reborrow())?;
         Ok(())
@@ -155,10 +149,7 @@ impl<'a, DB> QueryFragment<DB> for BoxedWhereClause<'a, DB>
 where
     DB: Backend,
 {
-    fn walk_ast<'b, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         match *self {
             BoxedWhereClause::Where(ref where_clause) => {
                 out.push_sql(" WHERE ");

--- a/diesel/src/query_dsl/positional_order_dsl.rs
+++ b/diesel/src/query_dsl/positional_order_dsl.rs
@@ -46,10 +46,7 @@ where
     Source: QueryFragment<DB>,
     Expr: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.source.walk_ast(pass.reborrow())?;
         pass.push_sql(" ORDER BY ");
         self.expr.walk_ast(pass)
@@ -60,10 +57,7 @@ where
 pub struct OrderColumn(u32);
 
 impl<DB: Backend> QueryFragment<DB> for OrderColumn {
-    fn walk_ast<'a, 'b>(&'a self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         pass.push_sql(&self.0.to_string());
         Ok(())
     }

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -185,10 +185,7 @@ where
     Right::FromClause: QueryFragment<DB>,
     Kind: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         self.left.from_clause.walk_ast(out.reborrow())?;
         self.kind.walk_ast(out.reborrow())?;
         out.push_sql(" JOIN ");
@@ -268,10 +265,7 @@ where
 pub struct Inner;
 
 impl<DB: Backend> QueryFragment<DB> for Inner {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" INNER");
         Ok(())
     }
@@ -282,10 +276,7 @@ impl<DB: Backend> QueryFragment<DB> for Inner {
 pub struct LeftOuter;
 
 impl<DB: Backend> QueryFragment<DB> for LeftOuter {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql(" LEFT OUTER");
         Ok(())
     }

--- a/diesel/src/sqlite/query_builder/limit_offset.rs
+++ b/diesel/src/sqlite/query_builder/limit_offset.rs
@@ -6,10 +6,7 @@ use crate::result::QueryResult;
 use crate::sqlite::Sqlite;
 
 impl QueryFragment<Sqlite> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
-    fn walk_ast<'a, 'b>(&'a self, _out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         Ok(())
     }
 }
@@ -18,10 +15,7 @@ impl<L> QueryFragment<Sqlite> for LimitOffsetClause<LimitClause<L>, NoOffsetClau
 where
     LimitClause<L>: QueryFragment<Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         self.limit_clause.walk_ast(out)?;
         Ok(())
     }
@@ -31,10 +25,7 @@ impl<O> QueryFragment<Sqlite> for LimitOffsetClause<NoLimitClause, OffsetClause<
 where
     OffsetClause<O>: QueryFragment<Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         // Sqlite requires a limit clause in front of any offset clause
         // using `LIMIT -1` is the same as not having any limit clause
         // https://sqlite.org/lang_select.html
@@ -49,10 +40,7 @@ where
     LimitClause<L>: QueryFragment<Sqlite>,
     OffsetClause<O>: QueryFragment<Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         self.limit_clause.walk_ast(out.reborrow())?;
         self.offset_clause.walk_ast(out.reborrow())?;
         Ok(())
@@ -60,10 +48,7 @@ where
 }
 
 impl<'a> QueryFragment<Sqlite> for BoxedLimitOffsetClause<'a, Sqlite> {
-    fn walk_ast<'b, 'c>(&'b self, mut out: AstPass<'_, 'c, Sqlite>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         match (self.limit.as_ref(), self.offset.as_ref()) {
             (Some(limit), Some(offset)) => {
                 limit.walk_ast(out.reborrow())?;

--- a/diesel/src/type_impls/tuples.rs
+++ b/diesel/src/type_impls/tuples.rs
@@ -75,9 +75,7 @@ macro_rules! tuple_impls {
 
             impl<$($T: QueryFragment<__DB>),+, __DB: Backend> QueryFragment<__DB> for ($($T,)+) {
                 #[allow(unused_assignments)]
-                fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, __DB>) -> QueryResult<()>
-                where
-                    'a: 'b
+                fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, __DB>) -> QueryResult<()>
                 {
                     let mut needs_comma = false;
                     $(

--- a/diesel_cli/src/query_helper.rs
+++ b/diesel_cli/src/query_helper.rs
@@ -26,7 +26,7 @@ impl DropDatabaseStatement {
 }
 
 impl<DB: Backend> QueryFragment<DB> for DropDatabaseStatement {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("DROP DATABASE ");
         if self.if_exists {
             out.push_sql("IF EXISTS ");
@@ -58,7 +58,7 @@ impl CreateDatabaseStatement {
 }
 
 impl<DB: Backend> QueryFragment<DB> for CreateDatabaseStatement {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.push_sql("CREATE DATABASE ");
         out.push_identifier(&self.db_name)?;
         Ok(())

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -134,8 +134,7 @@ pub(crate) fn expand(input: SqlFunctionDecl) -> Result<TokenStream, Diagnostic> 
             #(#arg_name: QueryFragment<__DieselInternal>,)*
         {
             #[allow(unused_assignments)]
-            fn walk_ast<'__a, '__b>(&'__a self, mut out: AstPass<'_, '__b, __DieselInternal>) -> QueryResult<()>
-            where '__a: '__b{
+            fn walk_ast<'__b>(&'__b self, mut out: AstPass<'_, '__b, __DieselInternal>) -> QueryResult<()>{
                 out.push_sql(concat!(#sql_name, "("));
                 // we unroll the arguments manually here, to prevent borrow check issues
                 let mut needs_comma = false;

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -63,7 +63,7 @@ where
     T: QueryFragment<DB>,
     U: Borrow<str>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.table.walk_ast(out.reborrow())?;
         out.push_sql(".");

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -57,7 +57,7 @@ impl<'a, DB, QS> QueryFragment<DB> for DynamicSelectClause<'a, DB, QS>
 where
     DB: Backend,
 {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut pass: AstPass<'_, 'c, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         let mut first = true;
         for s in &self.selects {
             if first {

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -94,7 +94,7 @@ where
     T: Borrow<str>,
     U: Borrow<str>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
         if let Some(ref schema) = self.schema {

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -157,10 +157,7 @@ impl<T, DB> QueryFragment<DB> for Arbitrary<T>
 where
     DB: Backend,
 {
-    fn walk_ast<'a, 'b>(&'a self, _: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, _: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         Ok(())
     }
 }

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -89,10 +89,7 @@ where
     DB: Backend,
     Cols: QueryFragment<DB>,
 {
-    fn walk_ast<'b, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_sql("CREATE TABLE IF NOT EXISTS ");
         out.push_identifier(self.name)?;
@@ -113,10 +110,7 @@ impl<'a, DB, T> QueryFragment<DB> for Column<'a, T>
 where
     DB: Backend,
 {
-    fn walk_ast<'b, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_identifier(self.name)?;
         out.push_sql(" ");
@@ -136,10 +130,7 @@ where
     DB: Backend,
     Col: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(" PRIMARY KEY");
@@ -158,10 +149,7 @@ impl<Col> QueryFragment<Sqlite> for AutoIncrement<Col>
 where
     Col: QueryFragment<Sqlite>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(" AUTOINCREMENT");
@@ -174,7 +162,7 @@ impl<Col> QueryFragment<Mysql> for AutoIncrement<Col>
 where
     Col: QueryFragment<Mysql>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(" AUTO_INCREMENT");
@@ -190,7 +178,7 @@ impl<Col> QueryId for AutoIncrement<Col> {
 
 #[cfg(feature = "postgres")]
 impl<'a> QueryFragment<Pg> for AutoIncrement<PrimaryKey<Column<'a, diesel::sql_types::Integer>>> {
-    fn walk_ast<'b: 'c, 'c>(&'b self, mut out: AstPass<'_, 'c, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         out.push_identifier((self.0).0.name)?;
         out.push_sql(" SERIAL PRIMARY KEY");
@@ -203,10 +191,7 @@ where
     DB: Backend,
     Col: QueryFragment<DB>,
 {
-    fn walk_ast<'a, 'b>(&'a self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()>
-    where
-        'a: 'b,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.0.walk_ast(out.reborrow())?;
         out.push_sql(" NOT NULL");
@@ -225,10 +210,7 @@ where
     DB: Backend,
     Col: QueryFragment<DB>,
 {
-    fn walk_ast<'b, 'c>(&'b self, mut out: AstPass<'_, 'c, DB>) -> QueryResult<()>
-    where
-        'b: 'c,
-    {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
         self.column.walk_ast(out.reborrow())?;
         out.push_sql(" DEFAULT ");

--- a/examples/postgres/advanced-blog-cli/src/pagination.rs
+++ b/examples/postgres/advanced-blog-cli/src/pagination.rs
@@ -61,7 +61,7 @@ impl<T> QueryFragment<Pg> for Paginated<T>
 where
     T: QueryFragment<Pg>,
 {
-    fn walk_ast<'a: 'b, 'b>(&'a self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
         self.query.walk_ast(out.reborrow())?;
         out.push_sql(") t LIMIT ");


### PR DESCRIPTION
Because non-mutable references (and other covariant types) always get their lifetimes automatically downgraded upon function calls, the AstPass functions can be rewritten in a much simpler way.

Apart from changes on the QueryFragment trait itself, all changes are made by regex_replace:
```
fn walk_ast<(?:'\w+(?:: '\w+)?, )?'\w+>\((\n*\s*)&'\w+ self,(\n*\s*)([\w\s]+): ([$\w:]*)AstPass<'_, '(_*)\w, ([$\w:]+)>(,?\n*\s*)\)\n*\s*->\n*\s*([$\w:]*)QueryResult<\(\)>(?:\n*\s*where\s*\n*\s*'\w+: '\w+,?)?
```
to
```
fn walk_ast<'$5b>($1&'$5b self,$2$3: $4AstPass<'_, '$5b, $6>$7) -> $8QueryResult<()>
```

I've named these lifetimes `'b`, but I'm open to renaming them `'qf` for query fragment or `'stmt` or something (super easy to do with the regex). I think these are easier to read if the lifetime name is always the same, like is done in serde with `'de`.
We may want to propagate that same lifetime name to `BindCollector`.