### PR TITLE
Backport formatting fixes (#4076, #4116, #4398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Adjust a custom compile error message
 * Fix a bug that restricted the number of allowed columns in `COPY FROM` statements to 12
 * Expose some SqliteValue helper functions
+* Use consistent whitespace in `ASC`/`DESC`, `DISTINCT ON`, and `DELETE FROM` clauses
 
 ## [2.2.7] 2025-01-31
 
@@ -65,10 +66,6 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Fixed a possible vulnerability in how Diesel handled protocol level bind parameters. 
   See the [SQL Injection isn't Dead: Smuggling Queries at Protocol Level](http://web.archive.org/web/20240812130923/https://media.defcon.org/DEF%20CON%2032/DEF%20CON%2032%20presentations/DEF%20CON%2032%20-%20Paul%20Gerste%20-%20SQL%20Injection%20Isn't%20Dead%20Smuggling%20Queries%20at%20the%20Protocol%20Level.pdf>) presentation from DEF CON for details
 * Fixed an issue with a possibly ambiguous trait resolution in `#[derive(QueryableByName)]`
-
-### Fixed
-
-* Use a single space instead of two spaces between `DELETE FROM`.
 
 ## [2.2.2] 2024-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
   See the [SQL Injection isn't Dead: Smuggling Queries at Protocol Level](http://web.archive.org/web/20240812130923/https://media.defcon.org/DEF%20CON%2032/DEF%20CON%2032%20presentations/DEF%20CON%2032%20-%20Paul%20Gerste%20-%20SQL%20Injection%20Isn't%20Dead%20Smuggling%20Queries%20at%20the%20Protocol%20Level.pdf>) presentation from DEF CON for details
 * Fixed an issue with a possibly ambiguous trait resolution in `#[derive(QueryableByName)]`
 
+### Fixed
+
+* Use a single space instead of two spaces between `DELETE FROM`.
+
 ## [2.2.2] 2024-07-19
 
 ### Fixed

--- a/diesel/src/expression/operators.rs
+++ b/diesel/src/expression/operators.rs
@@ -540,12 +540,12 @@ postfix_operator!(IsNull, " IS NULL");
 postfix_operator!(IsNotNull, " IS NOT NULL");
 postfix_operator!(
     Asc,
-    " ASC ",
+    " ASC",
     crate::expression::expression_types::NotSelectable
 );
 postfix_operator!(
     Desc,
-    " DESC ",
+    " DESC",
     crate::expression::expression_types::NotSelectable
 );
 

--- a/diesel/src/pg/query_builder/distinct_on.rs
+++ b/diesel/src/pg/query_builder/distinct_on.rs
@@ -271,7 +271,7 @@ where
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.push_sql("DISTINCT ON (");
         self.0.walk_ast(out.reborrow())?;
-        out.push_sql(")");
+        out.push_sql(") ");
         Ok(())
     }
 }

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -259,7 +259,7 @@ where
     Ret: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-        out.push_sql("DELETE ");
+        out.push_sql("DELETE");
         self.from_clause.walk_ast(out.reborrow())?;
         self.where_clause.walk_ast(out.reborrow())?;
         self.returning.walk_ast(out.reborrow())?;

--- a/examples/mysql/all_about_inserts/src/lib.rs
+++ b/examples/mysql/all_about_inserts/src/lib.rs
@@ -320,7 +320,7 @@ fn examine_sql_from_insert_get_results_batch() {
                     `users`.`hair_color`, `users`.`created_at`, \
                     `users`.`updated_at` \
                     FROM `users` \
-                    ORDER BY `users`.`id` DESC  \
+                    ORDER BY `users`.`id` DESC \
                     -- binds: []";
     assert_eq!(load_sql, debug_query::<Mysql, _>(&load_query).to_string());
 }
@@ -372,7 +372,7 @@ fn examine_sql_from_insert_get_result() {
                     `users`.`hair_color`, `users`.`created_at`, \
                     `users`.`updated_at` \
                     FROM `users` \
-                    ORDER BY `users`.`id` DESC  \
+                    ORDER BY `users`.`id` DESC \
                     -- binds: []";
     assert_eq!(load_sql, debug_query::<Mysql, _>(&load_query).to_string());
 }
@@ -399,7 +399,7 @@ fn examine_sql_from_explicit_returning() {
         debug_query::<Mysql, _>(&insert_query).to_string()
     );
     let load_query = users.select(id).order(id.desc());
-    let load_sql = "SELECT `users`.`id` FROM `users` ORDER BY `users`.`id` DESC  -- binds: []";
+    let load_sql = "SELECT `users`.`id` FROM `users` ORDER BY `users`.`id` DESC -- binds: []";
     assert_eq!(load_sql, debug_query::<Mysql, _>(&load_query).to_string());
 }
 


### PR DESCRIPTION
This pull request backports the formatting fixes that have been merged upstream from [#4076](https://github.com/diesel-rs/diesel/pull/4076), [#4116](https://github.com/diesel-rs/diesel/pull/4116), [#4398](https://github.com/diesel-rs/diesel/pull/4398), as has been suggested by @weiznich in https://github.com/diesel-rs/diesel/pull/4076#issuecomment-2661053763.